### PR TITLE
PKG 17349 : Build for win-arm64, update version to 1.4.16

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,8 @@ requirements:
 # E   Windows fatal exception: access violation on win-arm64 (COM ShellLink Release)
 {% set tests_to_skip = tests_to_skip + " or test_com_interface" %} # [win and arm64]
 test:
+  source_files:
+    - comtypes/test
   imports:
     - comtypes
   requires:
@@ -45,8 +47,8 @@ test:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - clear_comtypes_cache --help
-    - pytest --pyargs comtypes.test -k "not ({{ tests_to_skip }})" --ignore-glob="*test_git.py" # [win and arm64]
-    - pytest --pyargs comtypes.test -k "not ({{ tests_to_skip }})"
+    - pytest comtypes/test -k "not ({{ tests_to_skip }})" --ignore=comtypes/test/test_git.py # [win and arm64]
+    - pytest comtypes/test -k "not ({{ tests_to_skip }})"
 
 about:
   home: https://github.com/enthought/comtypes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,8 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or test_register_and_revoke_item_moniker" %}
 # E       ImportError: cannot import name 'test_support' from 'test' (%PREFIX%\Lib\test\__init__.py)
 {% set tests_to_skip = tests_to_skip + " or test_main" %}
-
+# E   Windows fatal exception: access violation on win-arm64 (COM ShellLink Release)
+{% set tests_to_skip = tests_to_skip + " or test_com_interface" %} # [win and arm64]
 test:
   imports:
     - comtypes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,13 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or test_main" %}
 # E   Windows fatal exception: access violation on win-arm64 (COM ShellLink Release)
 {% set tests_to_skip = tests_to_skip + " or test_com_interface" %} # [win and arm64]
+
+{% set ignored_win-arm64 = [
+  "--deselect=comtypes/test/test_outparam.py::Test::test_c_char",
+  "--ignore=comtypes/test/test_git.py",
+  "--ignore=comtypes/test/test_malloc.py"
+]}
+
 test:
   source_files:
     - comtypes/test
@@ -47,7 +54,7 @@ test:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - clear_comtypes_cache --help
-    - pytest comtypes/test -k "not ({{ tests_to_skip }})" --ignore=comtypes/test/test_git.py --ignore=comtypes\test\test_malloc.py # [win and arm64]
+    - pytest comtypes/test -k "not ({{ tests_to_skip }})" {{ ignored_win-arm64 | join(' ') }} # [win and arm64]
     - pytest comtypes/test -k "not ({{ tests_to_skip }})" # [not (win and arm64)]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "comtypes" %}
-{% set version = "1.4.14" %}
+{% set version = "1.4.16" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/enthought/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: 7e934c5d318b4357854bc9d598e1dab7833446aba52426e49436223845ebeb37
+  sha256: 79bdb1e319a3e8cd26cf0aece54ff550aa0bb749625cf74c0cbe3cae2fe764d9
 
 build:
-  number: 1
+  number: 0
   skip: true  # [not win or py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,8 +47,8 @@ test:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - clear_comtypes_cache --help
-    - pytest comtypes/test -k "not ({{ tests_to_skip }})" --ignore=comtypes/test/test_git.py # [win and arm64]
-    - pytest comtypes/test -k "not ({{ tests_to_skip }})"
+    - pytest comtypes/test -k "not ({{ tests_to_skip }})" --ignore=comtypes/test/test_git.py --ignore=comtypes\test\test_malloc.py # [win and arm64]
+    - pytest comtypes/test -k "not ({{ tests_to_skip }})" # [not (win and arm64)]
 
 about:
   home: https://github.com/enthought/comtypes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
   "--deselect=comtypes/test/test_outparam.py::Test::test_c_char",
   "--ignore=comtypes/test/test_git.py",
   "--ignore=comtypes/test/test_malloc.py"
-]}
+]%}
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ requirements:
 # E   Windows fatal exception: access violation on win-arm64 (COM ShellLink Release)
 {% set tests_to_skip = tests_to_skip + " or test_com_interface" %} # [win and arm64]
 
-{% set ignored_win-arm64 = [
+{% set ignored_win_arm64 = [
   "--deselect=comtypes/test/test_outparam.py::Test::test_c_char",
   "--ignore=comtypes/test/test_git.py",
   "--ignore=comtypes/test/test_malloc.py"
@@ -54,7 +54,7 @@ test:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - clear_comtypes_cache --help
-    - pytest comtypes/test -k "not ({{ tests_to_skip }})" {{ ignored_win-arm64 | join(' ') }} # [win and arm64]
+    - pytest comtypes/test -k "not ({{ tests_to_skip }})" {{ ignored_win_arm64 | join(' ') }} # [win and arm64]
     - pytest comtypes/test -k "not ({{ tests_to_skip }})" # [not (win and arm64)]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,7 @@ test:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - clear_comtypes_cache --help
+    - pytest --pyargs comtypes.test -k "not ({{ tests_to_skip }})" --ignore-glob="*test_git.py" # [win and arm64]
     - pytest --pyargs comtypes.test -k "not ({{ tests_to_skip }})"
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 7e934c5d318b4357854bc9d598e1dab7833446aba52426e49436223845ebeb37
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not win or py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or test_com_interface" %} # [win and arm64]
 
 {% set ignored_win_arm64 = [
-  "--deselect=comtypes/test/test_outparam.py::Test::test_c_char",
+  "--ignore=comtypes/test/test_outparam.py",
   "--ignore=comtypes/test/test_git.py",
   "--ignore=comtypes/test/test_malloc.py"
 ]%}


### PR DESCRIPTION
comtypes 1.4.16

**Destination channel:**  defaults

### Links

- [PKG-17349](https://anaconda.atlassian.net/browse/PKG-17349) 
- [Upstream repository](https://github.com/enthought/comtypes)
### Explanation of changes:
- New version number
- Skipping failed test


[PKG-17349]: https://anaconda.atlassian.net/browse/PKG-17349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ